### PR TITLE
Copy Chrome performance fix to background-map.js

### DIFF
--- a/lib/impact/background-map.js
+++ b/lib/impact/background-map.js
@@ -113,7 +113,13 @@ ig.BackgroundMap = ig.Map.extend({
 		}
 		ig.system.context = screenContext;
 		
-		return chunk;
+		// Workaround for Chrome 49 bug - handling many offscreen canvases
+		// seems to slow down the browser significantly. So we convert the
+		// canvas to an image.
+		var image = new Image();
+		image.src = chunk.toDataURL();
+
+		return image;
 	},
 	
 	


### PR DESCRIPTION
Chrome performance suffers greatly when drawing from too many canvases.

As a performance fix, `ig.Image.resize` was officially patched to convert canvases back into `Image`.

However, `ig.BackgroundMap` still suffers from the problem when pre-rendering is enabled.

This pull-request copies the original fix into the unpatched class.

Without this fix, my game runs about 5x slower when pre-rendering is enabled!