### PR TITLE
Update browse.php

### DIFF
--- a/lib/weltmeister/api/browse.php
+++ b/lib/weltmeister/api/browse.php
@@ -2,7 +2,7 @@
 require_once( 'config.php' );
 
 $dir = WM_Config::$fileRoot . str_replace( '..', '', $_GET['dir'] );
-if( $dir{strlen($dir)-1} != '/' ) {
+if( $dir[strlen($dir)-1] != '/' ) {
 	$dir .= '/';
 }
 


### PR DESCRIPTION
since PHP 7.4 curly braces method to get individual characters inside a string has been deprecated

It change from {} to []