### PR TITLE
Fix collisions when moving from one-way to slopes

### DIFF
--- a/lib/impact/collision-map.js
+++ b/lib/impact/collision-map.js
@@ -90,9 +90,10 @@ ig.CollisionMap = ig.Map.extend({
 				for( var tileY = firstTileY; tileY < lastTileY; tileY++ ) {
 					if( prevTileX != -1 ) {
 						t = this.data[tileY][prevTileX];
-						if(	
-							t > 1 && t <= this.lastSlope && 
-							this._checkTileDef(res, t, x, y, rvx, rvy, width, height, prevTileX, tileY) 
+						if(
+							t > 1 && t <= this.lastSlope &&
+							this._checkTileDef(res, t, x, y, rvx, rvy, width, height, prevTileX, tileY) &&
+							res.collision.slope.ny !== 0
 						) {
 							break;
 						}
@@ -137,9 +138,11 @@ ig.CollisionMap = ig.Map.extend({
 				for( var tileX = firstTileX; tileX < lastTileX; tileX++ ) {
 					if( prevTileY != -1 ) {
 						t = this.data[prevTileY][tileX];
-						if( 
+						if(
 							t > 1 && t <= this.lastSlope &&
-							this._checkTileDef(res, t, x, y, rvx, rvy, width, height, tileX, prevTileY) ) {
+							this._checkTileDef(res, t, x, y, rvx, rvy, width, height, tileX, prevTileY) &&
+							res.collision.slope.nx !== 0
+						) {
 							break;
 						}
 					}


### PR DESCRIPTION
When moving from one-way tiles to upward slopes, entities would get stuck at the edge of the slope and require upwards momentum to be able to continue moving forwards.

**Here's a sample entity trying to move up a slope from a one-way tile, previously:**
![Before](https://i.imgur.com/Jgjl1or.gif)

**Here's the entity freely moving up the slope with this fix:**
![After](https://i.imgur.com/HrQEfBo.gif)
